### PR TITLE
Use fuzzy translations in compilemessages

### DIFF
--- a/provisioning/roles/appserver/tasks/main.yml
+++ b/provisioning/roles/appserver/tasks/main.yml
@@ -81,7 +81,7 @@
 
 # Translations
 - name: Compile translation files
-  django_manage: command="compilemessages" app_path={{ project_dir }} virtualenv={{ root_dir }}/venv/
+  django_manage: command="compilemessages -f" app_path={{ project_dir }} virtualenv={{ root_dir }}/venv/
   when: translations
   tags: deploy
 


### PR DESCRIPTION
The reason is that otherwise compilemessage is too strict. I just had
the situation where the string "Forgot password" was translated to
"Passwort vergessen?". Without fuzzy translations, this entry will be
ignored, because the original string doesn't end with ? but the
translated one does.