### PR TITLE
Switch to python3 and latest ansible version

### DIFF
--- a/scripts/check_venv.sh
+++ b/scripts/check_venv.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 if [ ! -d "venv" ]; then
-    virtualenv -p python2 venv/
-    venv/bin/pip install ansible~=2.1.1.0
+    virtualenv -p python3 venv/
+    venv/bin/pip install ansible
 fi


### PR DESCRIPTION
Since ansible >=2.5 supports python >=3.5 there is no longer the need to
use either python2.7 or an outdated ansible version.