### PR TITLE
Fix issue with missing nodejs-legacy package

### DIFF
--- a/provisioning/roles/appserver/defaults/main.yml
+++ b/provisioning/roles/appserver/defaults/main.yml
@@ -3,3 +3,5 @@ email_from: webmaster@localhost
 
 static_url: http{% if ssl or behind_ssl|default(false) %}s{% endif %}://{{ full_domain }}{% if webserver_port != 80 %}:{{ webserver_port }}{% endif %}/{{ project_name }}-static/
 media_url: http{% if ssl or behind_ssl|default(false) %}s{% endif %}://{{ full_domain }}{% if webserver_port != 80 %}:{{ webserver_port }}{% endif %}/{{ project_name }}-media/
+
+nodejs_legacy_pkg: ''

--- a/provisioning/roles/appserver/tasks/main.yml
+++ b/provisioning/roles/appserver/tasks/main.yml
@@ -1,5 +1,9 @@
+- name: "Check if nodejs-legacy is needed"
+  set_fact:
+      nodejs_legacy_pkg: ',nodejs-legacy'
+  when: ( ansible_distribution == 'Ubuntu' and ansible_distribution_version is version('16.04', '<=')) or (ansible_distribution == 'Debian' and ansible_distribution_version is version('9', '<='))
 - name: Install uwsgi and python and other dependencies
-  apt: pkg=uwsgi,uwsgi-plugin-python3,python3-dev,virtualenv,python-pip,libpq-dev,nodejs-legacy,npm,git,gettext,libjpeg-dev state=installed update_cache=true
+  apt: pkg=uwsgi,uwsgi-plugin-python3,python3-dev,virtualenv,python-pip,libpq-dev,nodejs {{ nodejs_legacy_pkg }},npm,git,gettext,libjpeg-dev state=installed update_cache=true
   when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
 
 - name: Update git repo


### PR DESCRIPTION
Starting with Ubuntu 18.04 and Debian 10 the nodejs-legacy package is no
longer available/necessary. With these changes ansible checks if the nodejs-legacy package needs to be installed or not. 