### PR TITLE
Use python3-psycopg2 on dbserver for compatability with appserver

### DIFF
--- a/provisioning/roles/database/tasks/main.yml
+++ b/provisioning/roles/database/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: Install PostgreSQL
-  apt: pkg=postgresql,python-psycopg2 state=installed update_cache=true
+  apt: pkg=postgresql,python3-psycopg2 state=installed update_cache=true
   when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
 
 - name: Create Database


### PR DESCRIPTION
If we use python3 on the appserver we need python3-psycopg2 on the dbserver for compatability.