### PR TITLE
Update PIP to the newest version when creating the venv

### DIFF
--- a/scripts/check_venv.sh
+++ b/scripts/check_venv.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 if [ ! -d "venv" ]; then
     virtualenv -p python3 venv/
+    venv/bin/pip install -U pip
     venv/bin/pip install ansible
 fi


### PR DESCRIPTION
It may happen, that the PIP version of your Python version is not up to date when creating the virtualenv. Therefore PIP is complaining every time, that it is not up to date.
This PR solves that problem by updating it after creation of the virtualenv.