### PR TITLE
Remove space in package list

### DIFF
--- a/provisioning/roles/appserver/tasks/main.yml
+++ b/provisioning/roles/appserver/tasks/main.yml
@@ -3,7 +3,7 @@
       nodejs_legacy_pkg: ',nodejs-legacy'
   when: ( ansible_distribution == 'Ubuntu' and ansible_distribution_version is version('16.04', '<=')) or (ansible_distribution == 'Debian' and ansible_distribution_version is version('9', '<='))
 - name: Install uwsgi and python and other dependencies
-  apt: pkg=uwsgi,uwsgi-plugin-python3,python3-dev,virtualenv,python-pip,libpq-dev,nodejs {{ nodejs_legacy_pkg }},npm,git,gettext,libjpeg-dev state=installed update_cache=true
+  apt: pkg=uwsgi,uwsgi-plugin-python3,python3-dev,virtualenv,python-pip,libpq-dev,nodejs{{ nodejs_legacy_pkg }},npm,git,gettext,libjpeg-dev state=installed update_cache=true
   when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
 
 - name: Update git repo


### PR DESCRIPTION
Not all packages were installed because of this unneeded space in the package list if there is nothing specified for `nodejs_legacy_pkg`